### PR TITLE
feat: introduce onerror attribute

### DIFF
--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -141,6 +141,7 @@ impl Element {
     impl_attr!(rel);
     impl_attr!(target);
     impl_attr!(src);
+    impl_attr!(onerror);
     impl_attr!(integrity);
     impl_attr!(crossorigin);
     impl_attr!(role);


### PR DESCRIPTION
Onerror attribute is used on the img tags as fallback, in case the original image is not found.